### PR TITLE
Updated tests for 4chan's breaking API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ random.catalog(function(err, pages){
 	// but the list of threads only contains the OP
 });
 
-random.page(0, function(err, threads){
+random.page(1, function(err, threads){
 	// this will return an array of threads
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
    "name":"4chanjs",
    "description":"NodeJS and Browser 4chan API client",
-   "version":"0.1.0",
+   "version":"0.1.1",
    "homepage":"http://github.com/wearefractal/4chanjs",
    "repository":"git://github.com/wearefractal/4chanjs.git",
    "author":"Fractal <contact@wearefractal.com> (http://wearefractal.com/)",

--- a/test/main.js
+++ b/test/main.js
@@ -37,17 +37,17 @@ describe('4chan api', function() {
       	Array.isArray(pages).should.equal(true);
       	pages.length.should.not.equal(0);
       	should.exist(pages[0].page);
-      	pages[0].page.should.equal(0);
+      	pages[0].page.should.equal(1);
       	done();
       });
     });
   });
 
   describe('board.page()', function() {
-    it('should return a list of threads from page 0 of /b/', function(done) {
+    it('should return a list of threads from page 1 of /b/', function(done) {
       this.timeout(5000);
       var board = api.board('b');
-      board.page(0, function(err, threads){
+      board.page(1, function(err, threads){
       	should.not.exist(err);
       	should.exist(threads);
       	Array.isArray(threads).should.equal(true);
@@ -59,7 +59,7 @@ describe('4chan api', function() {
   });
 
   describe('board.threads()', function() {
-    it('should return a list of threads from page 0 of /b/', function(done) {
+    it('should return a list of threads from page 1 of /b/', function(done) {
       this.timeout(5000);
       var board = api.board('b');
       board.threads(function(err, pages){
@@ -78,7 +78,7 @@ describe('4chan api', function() {
       this.timeout(5000);
       var board = api.board('b');
       board.threads(function(err, pages){
-      	board.thread(pages[0].threads[0].no, function(err, thread){
+      	board.thread(pages[1].threads[0].no, function(err, thread){
       		should.not.exist(err);
 	      	should.exist(thread);
 	      	Array.isArray(thread).should.equal(true);


### PR DESCRIPTION
4chan now starts numbering boards starting from 1 instead of 0. This needlessly breaks the tests, because 4chanjs still works properly.
