### PR TITLE
Handling posts that have 404'd

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ api.board = function(board) {
 			if (body){
 				cb(null, body.posts);
 			} else {
-				cb(new Error('Not Found'), null);
+                err = new Error('Not Found');
+                err.code = "ENOTFOUND";
+                err.statusCode = 404;
+				cb(err, null);
 			}
 		});
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ api.board = function(board) {
 
 		request(uri, requestOptions, function(err, res, body){
 			if (err) return cb(err);
-			cb(null, body.posts);
+			if (body){
+				cb(null, body.posts);
+			} else {
+				cb(new Error('Not Found'), null);
+			}
 		});
 
 		return api;


### PR DESCRIPTION
Due to the volatile nature of the website, threads may 404 by the time that batch/rate limited, jobs have completed. To prevent an error, or failing silently, we should pass this as an error for the application to handle.
